### PR TITLE
Feature/unknown route handler

### DIFF
--- a/src/api-docs/__tests__/openAPIRouter.test.ts
+++ b/src/api-docs/__tests__/openAPIRouter.test.ts
@@ -13,7 +13,7 @@ describe('OpenAPI Router', () => {
       const expectedResponse = generateOpenAPIDocument();
 
       // Act
-      const response = await request(app).get('/swagger.json');
+      const response = await request(app).get('/api-docs/swagger.json');
 
       // Assert
       expect(response.status).toBe(StatusCodes.OK);
@@ -23,7 +23,7 @@ describe('OpenAPI Router', () => {
 
     it('should serve the Swagger UI', async () => {
       // Act
-      const response = await request(app).get('/');
+      const response = await request(app).get('/api-docs/');
 
       // Assert
       expect(response.status).toBe(StatusCodes.OK);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,6 @@ import express, { Express } from 'express';
 import helmet from 'helmet';
 import { pino } from 'pino';
 
-import { emailSettingsRouter } from '@/api/emailSettings/emailSettingsRouter';
 import { healthCheckRouter } from '@/api/healthCheck/healthCheckRouter';
 import { organizationRouter } from '@/api/organization/organizationRouter';
 import { userRouter } from '@/api/user/userRouter';
@@ -34,10 +33,9 @@ app.use(requestLogger);
 app.use('/health-check', healthCheckRouter);
 app.use('/organizations', organizationRouter);
 app.use('/users', userRouter);
-app.use('/email-settings', emailSettingsRouter);
 
 // Swagger UI
-app.use(openAPIRouter);
+app.use('/api-docs', openAPIRouter);
 
 // Error handlers
 app.use(errorHandler());


### PR DESCRIPTION
## Problem
The open api router was consuming all routes that were not defined specifically and it was returning the swagger documentation.

## Solution
Updated the route used to display the swagger docs to allow express to handle unknown routes with an appropriate 404 response and to keep our api documentation secure.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
REST Client
Manual Tests
Unit Tests

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Images:
<img width="959" alt="Screenshot 2024-07-25 171937" src="https://github.com/user-attachments/assets/ebb8a061-c0b3-4499-9f5e-3793be54e0a2">
<img width="958" alt="Screenshot 2024-07-25 171903" src="https://github.com/user-attachments/assets/3111ef8d-ca75-4066-b9e6-c4929448c4c2">
<img width="959" alt="Screenshot 2024-07-25 171824" src="https://github.com/user-attachments/assets/539fab10-4b55-40f6-86cc-a7f72f316c6a">