### PR TITLE
Pap 178 add intracom instance url to admin signup page

### DIFF
--- a/src/api/organization/organizationModel.ts
+++ b/src/api/organization/organizationModel.ts
@@ -5,6 +5,7 @@ import { Organization } from '@/api/organization/organizationSchema';
 const mongooseOrganizationSchema = new Schema<Organization>(
   {
     name: { type: String, required: true },
+    instanceUrl: { type: String, required: true },
   },
   { timestamps: true }
 );

--- a/src/api/organization/organizationRepository.ts
+++ b/src/api/organization/organizationRepository.ts
@@ -10,9 +10,7 @@ export const organizationRepository = {
   insert: async (org: BasicOrganization): Promise<Organization> => {
     try {
       await organizationRepository.startConnection();
-      const newOrg = new OrganizationModel({
-        name: org.name,
-      });
+      const newOrg = new OrganizationModel(org);
       return await newOrg.save();
     } catch (err) {
       console.error('[Error] OrganizationRepository - insert: ', err);

--- a/src/api/organization/organizationSchema.ts
+++ b/src/api/organization/organizationSchema.ts
@@ -7,6 +7,7 @@ extendZodWithOpenApi(z);
 
 export const OrganizationSchema = z.object({
   name: z.string().openapi({ example: 'Intracom Company' }),
+  instanceUrl: z.string().url().openapi({ example: 'https://example.com/' }),
 });
 
 export const OrganizationComplete = OrganizationSchema.merge(ModelID);

--- a/src/api/user/__tests__/userRouter.test.ts
+++ b/src/api/user/__tests__/userRouter.test.ts
@@ -164,6 +164,7 @@ describe('User API Endpoints', () => {
         password: 'Testing123!',
         username: 'newUser',
         organization: 'Example Corp.',
+        instanceUrl: 'https://www.example.com',
       };
 
       const userResponse = {

--- a/src/api/user/userService.ts
+++ b/src/api/user/userService.ts
@@ -113,6 +113,7 @@ export const userService = {
       const savedUser = await organizationRepository
         .insert({
           name: user.organization,
+          instanceUrl: user.instanceUrl,
         })
         .then(async (org) => {
           return await userRepository.insertUserAndOrganization({

--- a/src/api/user/userValidation.ts
+++ b/src/api/user/userValidation.ts
@@ -13,6 +13,10 @@ export const PostAdminUserSchema = z.object({
       username: z.string().min(5).openapi({ example: 'johndoe' }),
       organization: commonValidations.organization,
       password: commonValidations.password,
+      instanceUrl: z
+        .string()
+        .url({ message: 'Please provide a valid url.' })
+        .openapi({ example: 'https://www.example.com' }),
     })
     .superRefine(({ password }, checkPassComplexity) => {
       const containsUppercase = (ch: string) => /[A-Z]/.test(ch);


### PR DESCRIPTION
## Problem
In order to create a dynamic url we need the url of the server Intracom will be installed in. 

## Solution
Adding an instance url to the admin signup from will allow us to collect the instance url we need.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
We have automated test and we had to update the test to reflect the latest changes in order for the test to pass.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
